### PR TITLE
Allow use of a cookie to show Toolbar when logged out

### DIFF
--- a/config/toolbar.php
+++ b/config/toolbar.php
@@ -16,6 +16,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Statamic Cookie
+    |--------------------------------------------------------------------------
+    |
+    | If you provide a cookie name like "statamic_toolbar_cookie", then each
+    | time a user logs in the Toolbar will leave a cookie, making it possilbe
+    | to see the Toolbar even when it is disabled and you are not debugging.
+    |
+    */
+
+    'cookie' => env( 'STATAMIC_TOOLBAR_COOKIE', null ),
+
+    /*
+    |--------------------------------------------------------------------------
     | Components
     |--------------------------------------------------------------------------
     |

--- a/src/Controllers/ToolbarController.php
+++ b/src/Controllers/ToolbarController.php
@@ -6,6 +6,7 @@ use Heidkaemper\Toolbar\Breakpoints\Breakpoints;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Statamic\Facades\Entry;
+use Statamic\Facades\Preference;
 use Statamic\Facades\Site;
 use Statamic\Support\Str;
 
@@ -100,4 +101,22 @@ class ToolbarController extends Controller
 
         return $this->entry?->editUrl();
     }
+
+    public function canUseToolbarCookie(): bool 
+    {
+        if ( !config('statamic.cp.enabled') ) {
+            return false;
+        }
+
+        if ( !auth()->check() ) {
+            return false;
+        }
+
+        if ( !auth()->user()->can('access cp') || !auth()->user()->can('use toolbar cookie') ) {
+            return false;
+        }
+
+        return !Preference::get('toolbar_cookie_disabled', false);
+    }
+    
 }

--- a/src/Controllers/ToolbarController.php
+++ b/src/Controllers/ToolbarController.php
@@ -96,7 +96,10 @@ class ToolbarController extends Controller
     protected function getCpLink(): ?string
     {
         if (! config('statamic.toolbar.components.cp_link', true) || ! auth()->check()) {
-            return null;
+            $cookie = request()->cookie(config( 'statamic.toolbar.cookie', '') );
+            if (!$cookie) {
+                return null;
+            }
         }
 
         return $this->entry?->editUrl();

--- a/src/Listeners/LoginListener.php
+++ b/src/Listeners/LoginListener.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Heidkaemper\Toolbar\Listeners;
+
+use Heidkaemper\Toolbar\Controllers\ToolbarController;
+use Illuminate\Auth\Events\Login;
+
+class LoginListener 
+{
+    protected ToolbarController $controller;
+
+    public function __construct(ToolbarController $controller) 
+    {
+        $this->controller = $controller;
+    }
+
+    public function handle(Login $event): void 
+    {
+        $cookie_name = config('statamic.toolbar.cookie');
+        if ( $cookie_name && $this->controller->canUseToolbarCookie() ) {
+            cookie()->queue($cookie_name, true, 60 * 24 * 7); // 7 days}
+        }
+    }
+}

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -3,11 +3,17 @@
 namespace Heidkaemper\Toolbar;
 
 use Heidkaemper\Toolbar\Middleware\InjectToolbar;
+use Statamic\Facades\Permission;
+use Statamic\Facades\Preference;
 use Statamic\Providers\AddonServiceProvider;
 use Statamic\Statamic;
 
 class ServiceProvider extends AddonServiceProvider
 {
+    protected $listen = [
+		'Illuminate/Auth/Events/Login' => ['Heidkaemper\Toolbar\Listeners\LoginListener'],
+	];
+
     public function boot()
     {
         parent::boot();
@@ -17,6 +23,7 @@ class ServiceProvider extends AddonServiceProvider
                 ->bootAddonRoutes()
                 ->bootAddonMiddleware()
                 ->bootAddonViews()
+				->bootAddonPermissions()
                 ->publishAddonAssets();
         });
     }
@@ -56,6 +63,35 @@ class ServiceProvider extends AddonServiceProvider
 
         return $this;
     }
+
+	protected function bootAddonPermissions() {
+		Permission::extend( function () {
+			Permission::group( 'statamic_toolbar', 'Toolbar', function () {
+				Permission::register( 'use toolbar cookie' )
+					->label( __( 'Can save toolbar cookie' ) );
+			} );
+		} );
+
+		Preference::extend( fn( $preference ) => [
+			'general' => [
+				'display' => __( 'Toolbar' ),
+				'fields' => [
+					'statamic_toolbar' => [
+						'type' => 'section',
+						'display' => __( 'Toolbar' ),
+					],
+					'toolbar_cookie_disabled' => [
+						'type' => 'toggle',
+						'display' => __( 'Save a Cookie to enable the Toolbar' ),
+						'width' => '100',
+						'default' => true,
+					],
+				],
+			],
+		] );
+
+		return $this;
+	}
 
     protected function publishAddonAssets(): void
     {

--- a/src/Toolbar.php
+++ b/src/Toolbar.php
@@ -3,13 +3,19 @@
 namespace Heidkaemper\Toolbar;
 
 use Composer\InstalledVersions;
+use Statamic\Facades\Preference;
 use Symfony\Component\HttpFoundation\Response;
 
 class Toolbar
 {
     public function isEnabled(): bool
     {
-        return config('statamic.toolbar.enabled') ?? config('app.debug', false);
+        $cookie = null;
+        if ( Preference::get( 'toolbar_cookie_disabled', true ) ) {
+            $cname = config( 'statamic.toolbar.cookie', '' );
+            $cookie = request()->cookie( $cname );
+        }
+        return config( 'statamic.toolbar.enabled' ) ?? $cookie ?? config( 'app.debug', false );
     }
 
     public function inject(Response $response): void


### PR DESCRIPTION
This pull request is related to issue #13 which I posted earlier today. This facilitates the use of the Toolbar even in production environments, by providing a cookie which can control whether it is rendered or not. These changes should make no difference in how the Toolbar runs unless changes are made to the `.env` file.

If you also add something like the following to the `.env` file, then Toolbar will use that cookie to allow it to display even when not debugging. It accomplishes this by storing the cookie when the user first logs in normally, and then referring to that cookie when the user is logged out. After the cookie is in place, anyone using that browser for the next seven days will see the Toolbar.

Add this to `.env` to see this in action...
```sh
APP_DEBUG=false
STATAMIC_TOOLBAR_COOKIE=statamic_toolbar_cookie
```
Of course, the cookie could be named anything you like.
